### PR TITLE
 Update Html5DateTimeFormat.groovy time() function - to get it work with...

### DIFF
--- a/src/groovy/grails/plugin/jodatime/Html5DateTimeFormat.groovy
+++ b/src/groovy/grails/plugin/jodatime/Html5DateTimeFormat.groovy
@@ -5,6 +5,7 @@ import org.joda.time.format.DateTimeFormat
 import org.joda.time.format.DateTimeFormatterBuilder
 import org.joda.time.format.ISODateTimeFormat
 import org.joda.time.format.DateTimePrinter
+import org.joda.time.format.DateTimeParser
 
 /**
  * Provides a set of DateTimeFormatters that parse and format correctly for the various HTML5 date & time input types.


### PR DESCRIPTION
... actual version of Joda-Time

There was bug in Joda-time DateTimeFormatter which was fixed in version 2.2. See [http://www.joda.org/joda-time/upgradeto220.html](http://www.joda.org/joda-time/upgradeto220.html) for more info.

So when Joda-Time >=2.2 is used, DateTimeFormatter time() stopped working.

This fixed implementation will work with old (2.0) and all newer versions to..
