### PR TITLE
Grails version now 2.3.5, default uses Spock.

### DIFF
--- a/test/projects/joda-time-test/application.properties
+++ b/test/projects/joda-time-test/application.properties
@@ -1,5 +1,5 @@
 #Grails Metadata file
 #Sun Oct 28 08:49:45 GMT 2012
-app.grails.version=2.3.3
+app.grails.version=2.3.5
 app.name=joda-time-test
 app.version=0.1

--- a/test/projects/joda-time-test/grails-app/conf/BuildConfig.groovy
+++ b/test/projects/joda-time-test/grails-app/conf/BuildConfig.groovy
@@ -19,8 +19,7 @@ grails.project.dependency.resolution = {
 	def seleniumVersion = '2.28.0'
 
 	dependencies {
-		test 'org.spockframework:spock-grails-support:0.7-groovy-2.0',
-				"org.seleniumhq.selenium:selenium-chrome-driver:$seleniumVersion",
+		test "org.seleniumhq.selenium:selenium-chrome-driver:$seleniumVersion",
 				"org.seleniumhq.selenium:selenium-support:$seleniumVersion",
 				"org.gebish:geb-spock:$gebVersion"
 		compile 'org.jadira.usertype:usertype.jodatime:1.9'

--- a/test/projects/joda-time-test/test/integration/jodatest/AutoTimestampingSpec.groovy
+++ b/test/projects/joda-time-test/test/integration/jodatest/AutoTimestampingSpec.groovy
@@ -1,6 +1,7 @@
 package jodatest
 
-import grails.plugin.spock.IntegrationSpec
+import grails.test.spock.IntegrationSpec
+
 
 class AutoTimestampingSpec extends IntegrationSpec {
 

--- a/test/projects/joda-time-test/test/integration/jodatest/DomainClassSpec.groovy
+++ b/test/projects/joda-time-test/test/integration/jodatest/DomainClassSpec.groovy
@@ -1,6 +1,6 @@
 package jodatest
 
-import grails.plugin.spock.IntegrationSpec
+import grails.test.spock.IntegrationSpec
 import org.joda.time.DateTime
 
 class DomainClassSpec extends IntegrationSpec {


### PR DESCRIPTION
Removed spock from BuildConfig.
Changed import in IntegrationSpecs to use correct IntegrationSpec class.
