### PR TITLE
IDLW timezone as default

### DIFF
--- a/test/unit/grails/plugin/jodatime/binding/StructuredDateTimeEditorSpec.groovy
+++ b/test/unit/grails/plugin/jodatime/binding/StructuredDateTimeEditorSpec.groovy
@@ -26,7 +26,7 @@ class StructuredDateTimeEditorSpec extends Specification {
 	
 	def setupSpec() {
 		zone = DateTimeZone.default
-		DateTimeZone.default = DateTimeZone.forID("Europe/London")
+		DateTimeZone.default = DateTimeZone.forID("Etc/GMT+12")
 	}
 	
 	def cleanupSpec() {
@@ -48,7 +48,7 @@ class StructuredDateTimeEditorSpec extends Specification {
 		DateTime      | [year: "2009", month: "03", day: "06", hour: "17", minute: "21", second: "33"]              | new DateTime(2009, 3, 6, 17, 21, 33, 0)
 		LocalTime     | [hour: "17"]                                                                                | new LocalTime(17, 0)
 		LocalTime     | [hour: "17", minute: "55", second: "33"]                                                    | new LocalTime(17, 55, 33)
-		DateTime      | [year: "2009", month: "08", day: "24", hour: "13", minute: "06"]                            | new DateTime(2009, 8, 24, 13, 6, 0, 0).withZoneRetainFields(DateTimeZone.forID("Europe/London"))
+		DateTime      | [year: "2009", month: "08", day: "24", hour: "13", minute: "06"]                            | new DateTime(2009, 8, 24, 13, 6, 0, 0).withZoneRetainFields(DateTimeZone.forID("Etc/GMT+12"))
 		DateTime      | [year: "2009", month: "08", day: "24", hour: "13", minute: "06", zone: "America/Vancouver"] | new DateTime(2009, 8, 24, 13, 6, 0, 0).withZoneRetainFields(DateTimeZone.forID("America/Vancouver"))
 	}
 

--- a/test/unit/grails/plugin/jodatime/converters/JSONBindingSpec.groovy
+++ b/test/unit/grails/plugin/jodatime/converters/JSONBindingSpec.groovy
@@ -37,7 +37,7 @@ class JSONBindingSpec extends Specification {
 
 	void setupSpec() {
 		originalTimeZone = DateTimeZone.default
-		DateTimeZone.default = DateTimeZone.forID("America/Vancouver")
+		DateTimeZone.default = DateTimeZone.forID("Etc/GMT+12")
 	}
 
 	void cleanupSpec() {

--- a/test/unit/grails/plugin/jodatime/converters/JSONBindingSpec.groovy
+++ b/test/unit/grails/plugin/jodatime/converters/JSONBindingSpec.groovy
@@ -65,14 +65,10 @@ class JSONBindingSpec extends Specification {
 
 		where:
 		value                           | expected
-    // this isn't really correct but it's not clear where this conversion is done
-//		'2014-04-23T04:30:45.123Z'      | new DateTime(2014, 4, 23, 4, 30, 45, 123).withZone(UTC)
-//		'2014-04-23T04:30:45.123+01:00' | new DateTime(2014, 4, 23, 4, 30, 45, 123).withZone(DateTimeZone.forOffsetHours(1))
-		'2014-04-23T04:30:45.123Z'      | new DateTime(2014, 4, 22, 21, 30, 45, 123).withZone(DateTimeZone.default)
-		'2014-04-23T04:30:45.123+01:00' | new DateTime(2014, 4, 22, 20, 30, 45, 123).withZone(DateTimeZone.default)
-    // end
-		'2014-04-23T04:30:45.123'       | new DateTime(2014, 4, 23, 4, 30, 45, 123).withZone(DateTimeZone.default)
-		'2014-04-23T04:30'              | new DateTime(2014, 4, 23, 4, 30).withZone(DateTimeZone.default)
+		'2014-04-23T04:30:45.123Z'      | new DateTime(2014, 4, 23, 4, 30, 45, 123, UTC)
+		'2014-04-23T04:30:45.123+01:00' | new DateTime(2014, 4, 23, 4, 30, 45, 123, DateTimeZone.forOffsetHours(1))
+		'2014-04-23T04:30:45.123'       | new DateTime(2014, 4, 23, 4, 30, 45, 123, DateTimeZone.default)
+		'2014-04-23T04:30'              | new DateTime(2014, 4, 23, 4, 30, DateTimeZone.default)
 		'2014-04-23T04:30:45.123'       | new LocalDateTime(2014, 4, 23, 4, 30, 45, 123)
 		'2014-04-23T04:30:45'           | new LocalDateTime(2014, 4, 23, 4, 30, 45)
 		'04:30:45.123'                  | new LocalTime(4, 30, 45, 123)


### PR DESCRIPTION
Used UTC-12:00 (Etc/GMT+12) timezone in tests that uses system default time zone because in some cases they may be equal with developer machine.
UTC-12:00 is not used by anyone in the world https://en.wikipedia.org/wiki/UTC%E2%88%9212:00 , at least who can run a tests